### PR TITLE
Fix memory leak on destruction

### DIFF
--- a/Plugin/GUB/Source/gub_pipeline.c
+++ b/Plugin/GUB/Source/gub_pipeline.c
@@ -96,13 +96,13 @@ EXPORT_API void gub_pipeline_close(GUBPipeline *pipeline)
     if (pipeline->last_sample) {
         gst_sample_unref(pipeline->last_sample);
     }
+    g_free(pipeline->name);
     memset(pipeline, 0, sizeof(GUBPipeline));
 }
 
 EXPORT_API void gub_pipeline_destroy(GUBPipeline *pipeline)
 {
     gub_pipeline_close(pipeline);
-    g_free(pipeline->name);
     free(pipeline);
 }
 


### PR DESCRIPTION
The call to g_free has to occur before the whole struct gets zeroed ; otherwise it's a no-op.